### PR TITLE
Search instruments

### DIFF
--- a/src/harmony/matching/matcher.py
+++ b/src/harmony/matching/matcher.py
@@ -466,7 +466,6 @@ def match_query_with_catalogue_instruments(
         "all_embeddings_concatenated"
     ]
     all_catalogue_instruments: List[dict] = catalogue_data["all_instruments"]
-    all_catalogue_questions: List[str] = catalogue_data["all_questions"]
 
     # No embeddings = nothing to find
     if len(all_catalogue_questions_embeddings_concatenated) == 0:

--- a/src/harmony/matching/matcher.py
+++ b/src/harmony/matching/matcher.py
@@ -444,14 +444,16 @@ def match_query_with_catalogue_instruments(
         catalogue_data: dict,
         vectorisation_function: Callable,
         texts_cached_vectors: dict[str, List[float]],
+        max_results: int = 100,
 ) -> dict[str, list | dict]:
     """
-    Match a query with catalogue instruments.
+    Match query with catalogue instruments.
 
     :param query: The query.
     :param catalogue_data: The catalogue data.
     :param vectorisation_function: A function to vectorize a text.
     :param texts_cached_vectors: A dictionary of already cached text vectors (text to vector).
+    :param max_results: The max amount of instruments to return.
     :return: A dict containing the list of instruments (up to 100) and the new text vectors.
         E.g. {"instruments": [...], "new_text_vectors": {...}}.
     """
@@ -492,10 +494,9 @@ def match_query_with_catalogue_instruments(
 
     # Get indexes of top matching questions in the catalogue
     # The first index contains the best match
-    top_n = 100
     top_catalogue_questions_matches_idxs = [
         catalogue_questions_similarities_for_query.index(i)
-        for i in heapq.nlargest(top_n, catalogue_questions_similarities_for_query)
+        for i in heapq.nlargest(max_results, catalogue_questions_similarities_for_query)
     ]
 
     # A dict of matching instruments

--- a/src/harmony/schemas/requests/text.py
+++ b/src/harmony/schemas/requests/text.py
@@ -70,6 +70,9 @@ class Question(BaseModel):
     closest_catalogue_question_match: Optional[CatalogueQuestion] = Field(
         None, description="The closest question match in the catalogue for the question"
     )
+    seen_in_catalogue_instruments: list[CatalogueInstrument] = Field(
+        default=None, description="The instruments from the catalogue were the question was seen in"
+    )
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
@@ -97,7 +100,7 @@ class Instrument(BaseModel):
                                description="The ISO 639-2 (alpha-2) encoding of the instrument language")
     questions: List[Question] = Field(description="The items inside the instrument")
     closest_catalogue_instrument_matches: List[CatalogueInstrument] = Field(
-        [],
+        None,
         description="The closest instrument matches in the catalogue for the instrument, the first index "
                     "contains the best match etc"
     )
@@ -199,6 +202,17 @@ class MatchBody(BaseModel):
 
                 ],
                 "query": "anxiety",
+                "parameters": {"framework": DEFAULT_FRAMEWORK,
+                               "model": DEFAULT_MODEL}
+            }
+        })
+
+
+class SearchInstrumentsBody(BaseModel):
+    parameters: MatchParameters = Field(DEFAULT_MATCH_PARAMETERS, description="Parameters on how to search")
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
                 "parameters": {"framework": DEFAULT_FRAMEWORK,
                                "model": DEFAULT_MODEL}
             }

--- a/src/harmony/schemas/responses/text.py
+++ b/src/harmony/schemas/responses/text.py
@@ -49,6 +49,10 @@ class MatchResponse(BaseModel):
     )
 
 
+class SearchInstrumentsResponse(BaseModel):
+    instruments: List[Instrument] = Field(description="A list of instruments")
+
+
 class InstrumentList(RootModel):
     root: List[Instrument]
 


### PR DESCRIPTION
## Description

Add function `match_query_with_catalogue_instruments` to `matcher.py` for matching a query with the instruments in the catalogue.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
