### PR TITLE
added batching to matcher.py and unit tests

### DIFF
--- a/tests/test_batching_in_matcher.py
+++ b/tests/test_batching_in_matcher.py
@@ -1,0 +1,84 @@
+import sys
+import os
+import unittest
+import numpy
+
+sys.path.append("../src")
+from unittest import TestCase, mock
+from harmony.matching.matcher import get_batch_size
+from harmony.matching.matcher import process_items_in_batches
+
+
+# Mock LLM function
+def mock_llm_function(batch):
+    """Simulates processing a batch."""
+    return [f"Processed: {item}" for item in batch]
+
+
+class TestMatcherBatching(TestCase):
+
+    @mock.patch.dict(os.environ, {"BATCH_SIZE": "5"})
+    def test_batched_processing(self):
+        """Test that 10 items are divided into 2 batches of 5 each."""
+        items = [f"item{i}" for i in range(10)]  # 10 items to process
+        results = process_items_in_batches(items, mock_llm_function)
+
+        self.assertEqual(len(results), 10)
+
+        expected = [
+            "Processed: item0", "Processed: item1", "Processed: item2", "Processed: item3", "Processed: item4",
+            "Processed: item5", "Processed: item6", "Processed: item7", "Processed: item8", "Processed: item9",
+        ]
+        self.assertEqual(results, expected)
+
+    @mock.patch.dict(os.environ, {"BATCH_SIZE": "5"})
+    def test_large_batch_size(self):
+        """Test batch size greater than input size."""
+        items = [f"item{i}" for i in range(3)]  # Only 3 items
+        results = process_items_in_batches(items, mock_llm_function)
+
+        self.assertEqual(len(results), 3)
+
+        expected = [
+            "Processed: item0", "Processed: item1", "Processed: item2",
+        ]
+        self.assertEqual(results, expected)
+
+    @mock.patch.dict(os.environ, {"BATCH_SIZE": "0"})
+    def test_no_batching(self):
+        """Test no batching (all items processed in one batch)."""
+        items = [f"item{i}" for i in range(10)]  # 10 items to process
+        results = process_items_in_batches(items, mock_llm_function)
+
+        self.assertEqual(len(results), 10)
+
+        expected = [
+            "Processed: item0", "Processed: item1", "Processed: item2", "Processed: item3", "Processed: item4",
+            "Processed: item5", "Processed: item6", "Processed: item7", "Processed: item8", "Processed: item9",
+        ]
+        self.assertEqual(results, expected)
+
+    @mock.patch.dict(os.environ, {"BATCH_SIZE": "-5"})
+    def test_negative_batch_size(self):
+        """Test when BATCH_SIZE is negative, it defaults to 0."""
+        items = [f"item{i}" for i in range(10)]
+        results = process_items_in_batches(items, mock_llm_function)
+        self.assertEqual(len(results), 10)
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_default_batch_size(self):
+        """Test when BATCH_SIZE is not set, it defaults to 50."""
+        items = [f"item{i}" for i in range(10)]
+        results = process_items_in_batches(items, mock_llm_function)
+        self.assertEqual(len(results), 10)
+
+    @mock.patch.dict(os.environ, {"BATCH_SIZE": "invalid"})
+    def test_invalid_batch_size(self):
+        """Test when BATCH_SIZE is invalid, it defaults to 50."""
+        items = [f"item{i}" for i in range(10)]
+        results = process_items_in_batches(items, mock_llm_function)
+        self.assertEqual(len(results), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

A new environment variable, BATCH_SIZE, was introduced in the matcher.py file to control the batch size when sending items to the LLM. The default value for BATCH_SIZE is 50 if the environment variable is not explicitly set.

Additionally, a function process_items_in_batches() was added to implement the batching logic. This function divides the input items into batches based on the BATCH_SIZE value and processes them accordingly. Special handling ensures that when BATCH_SIZE is set to 0, all items are processed together in a single batch. 


#### Fixes #63

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing

Six unit tests were implemented to verify the functionallity of the batching logic:

- Test for basic batching: Confirms that 10 items are split into 2 batches when BATCH_SIZE is set to 5.
- Test for single batch: Ensures that when BATCH_SIZE exceeds the number of items, all items are processed in a single batch.
- Test for BATCH_SIZE == 0: Validates that batching is disabled, and all items are processed together.
- Test for negative BATCH_SIZE: Ensures that when BATCH_SIZE is set to a negative value, it defaults to 0.
- Test for default behavior: Confirms that BATCH_SIZE defaults to 50 when the environment variable is not set.
- Test for invalid BATCH_SIZE: Verifies that BATCH_SIZE defaults to 50 if set to an invalid value.


#### Test Configuration

* Library version:
* OS: Windows11
* Toolchain: 3.10.0

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings