### PR TITLE
Allow user to turn on/off the negation behaviour #59

### DIFF
--- a/src/harmony/matching/default_matcher.py
+++ b/src/harmony/matching/default_matcher.py
@@ -75,7 +75,7 @@ def match_instruments(
         mhc_all_metadatas: List = [],
         mhc_embeddings: np.ndarray = np.zeros((0, 0)),
         texts_cached_vectors: dict[str, List[float]] = {}, batch_size: int = 1000, max_batches: int = 2000,
-
+        is_negate: bool = True
 ) -> tuple:
     return match_instruments_with_function(
         instruments=instruments,
@@ -86,4 +86,5 @@ def match_instruments(
         mhc_all_metadatas=mhc_all_metadatas,
         mhc_embeddings=mhc_embeddings,
         texts_cached_vectors=texts_cached_vectors,
+        is_negate = is_negate
     )

--- a/src/harmony/matching/matcher.py
+++ b/src/harmony/matching/matcher.py
@@ -96,11 +96,14 @@ def add_text_to_vec(text, texts_cached_vectors, text_vectors, is_negated_, is_qu
     return text_vectors
 
 
-def process_questions(questions, texts_cached_vectors) -> list[TextVector]:
+def process_questions(questions: list, texts_cached_vectors: dict, is_negate: bool) -> list[TextVector]:
     text_vectors: List[TextVector] = []
     for question_text in questions:
         text_vectors = add_text_to_vec(question_text, texts_cached_vectors, text_vectors, False, False)
-        negated_text = negate(question_text, 'en')
+        if is_negate:
+            negated_text = negate(question_text, 'en')
+        else:
+            negated_text = question_text
         text_vectors = add_text_to_vec(negated_text, texts_cached_vectors, text_vectors, True, False)
     return text_vectors
 
@@ -137,13 +140,14 @@ def create_full_text_vectors(
         query: str | None,
         vectorisation_function: Callable,
         texts_cached_vectors: dict[str, list[float]],
+        is_negate: bool
 ) -> tuple[List[TextVector], dict]:
     """
     Create full text vectors.
     """
 
     # Create a list of text vectors
-    text_vectors = process_questions(all_questions, texts_cached_vectors)
+    text_vectors = process_questions(all_questions, texts_cached_vectors, is_negate=is_negate)
 
     # Add query
     if query:
@@ -177,6 +181,7 @@ def match_instruments_with_catalogue_instruments(
         catalogue_data: dict,
         vectorisation_function: Callable,
         texts_cached_vectors: dict[str, List[float]],
+        is_negate: bool = True
 ) -> tuple[List[Instrument], List[CatalogueInstrument]]:
     """
     Match instruments with catalogue instruments.
@@ -201,6 +206,7 @@ def match_instruments_with_catalogue_instruments(
         query=None,
         vectorisation_function=vectorisation_function,
         texts_cached_vectors=texts_cached_vectors,
+        is_negate=is_negate
     )
 
     # For each instrument, find the best instrument matches for it in the catalogue
@@ -475,6 +481,7 @@ def match_query_with_catalogue_instruments(
         vectorisation_function: Callable,
         texts_cached_vectors: dict[str, List[float]],
         max_results: int = 100,
+        is_negate: bool = True
 ) -> dict[str, list | dict]:
     """
     Match query with catalogue instruments.
@@ -509,6 +516,7 @@ def match_query_with_catalogue_instruments(
         query=query,
         vectorisation_function=vectorisation_function,
         texts_cached_vectors=texts_cached_vectors,
+        is_negate=is_negate
     )
 
     # Get an array of dimensions
@@ -568,6 +576,7 @@ def match_instruments_with_function(
         mhc_all_metadatas: List = [],
         mhc_embeddings: np.ndarray = np.zeros((0, 0)),
         texts_cached_vectors: dict[str, List[float]] = {},
+        is_negate: bool = True
 ) -> tuple:
     """
     Match instruments.
@@ -589,7 +598,8 @@ def match_instruments_with_function(
         all_questions=[q.question_text for q in all_questions],
         query=query,
         vectorisation_function=vectorisation_function,
-        texts_cached_vectors=texts_cached_vectors
+        texts_cached_vectors=texts_cached_vectors,
+        is_negate=is_negate
     )
 
     # get vectors for all original texts and vectors for negated texts

--- a/tests/test_match_negative_polarity.py
+++ b/tests/test_match_negative_polarity.py
@@ -1,0 +1,64 @@
+'''
+MIT License
+
+Copyright (c) 2023 Ulster University (https://www.ulster.ac.uk).
+Project: Harmony (https://harmonydata.ac.uk)
+Maintainer: Thomas Wood (https://fastdatascience.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+'''
+
+import sys
+import unittest
+
+sys.path.append("../src")
+
+from harmony import match_instruments
+from harmony.schemas.requests.text import Instrument, Question
+
+questions_en = [Question(question_text="I feel nervous"),
+                Question(question_text="I don't feel nervous")]
+instrument_en = Instrument(questions=questions_en)
+
+
+class TestMatch(unittest.TestCase):
+
+    def test_single_instrument_with_negation_on_as_default(self):
+        all_questions, similarity_with_polarity, query_similarity, new_vectors_dict = match_instruments([instrument_en])
+        self.assertEqual(2, len(all_questions))
+        self.assertEqual(2, len(similarity_with_polarity))
+        self.assertLess(0.99, similarity_with_polarity[0][0])
+        self.assertGreater(0, similarity_with_polarity[0][1])
+        self.assertLess(0.99, similarity_with_polarity[1][1])
+        self.assertGreater(0, similarity_with_polarity[1][0])
+
+    def test_single_instrument_without_negation(self):
+        all_questions, similarity_with_polarity, query_similarity, new_vectors_dict = match_instruments([instrument_en],
+                                                                                                        is_negate=False)
+        self.assertEqual(2, len(all_questions))
+        self.assertEqual(2, len(similarity_with_polarity))
+        self.assertLess(0.99, similarity_with_polarity[0][0])
+        self.assertLess(0, similarity_with_polarity[0][1])
+        self.assertLess(0.99, similarity_with_polarity[1][1])
+        self.assertLess(0, similarity_with_polarity[1][0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Question negation is language specific but not always wanted. This PR is to enable/disable it at the `match_instruments` function

To clarify, there are some rule based scripts [here](https://github.com/harmonydata/harmony/blob/main/src/harmony/matching/negator.py) which turn "I like" into "I don't like" etc in English and a few other languages. This is hard coded and some users want to be able to **turn it off**.

I added a switch at library level and also [at API level](https://github.com/harmonydata/harmonyapi/issues/11) which stops the functions in `negator.py` being called

Once we have enabled this switch we need to expose it as an option in the API. I have a [related issue in the API issue tracker covering this function on the API side](https://github.com/harmonydata/harmonyapi/issues/11). However, the first step is to implement this switch in the Python library

#### Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Requires a documentation revision

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] `test_match_negative_polarity.py` - tests that the negation is being turned on/off

Since the Harmony Python package is used by the Harmony API (which is itself used by the R library and the web app), we need to avoid making any changes that break the Harmony API. Please also run the Harmony API unit tests and check that the API still runs with your changes to the Python package: https://github.com/harmonydata/harmonyapi

#### Test Configuration

* Library version: 1.0.1
* OS: Ubuntu
* Toolchain: Pycharm  Python 3.10.12


## Checklist

- [X] My code follows the style guidelines of this project. I have applied a Linter (recommended: Pycharm's code formatter) to make my whitespace consistent with the rest of the project.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] The Harmony API is not broken by my change to the Harmony Python library
- [N/A] I add third party dependencies only when necessary. If I changed the requirements, it changes in `requirements.txt`, `pyproject.toml` and also in the `requirements.txt` in the [API repo](https://github.com/harmonydata/harmonyapi)
- [N/A] If I introduced a new feature, I documented it (e.g. making a script example in the [script examples repository](https://github.com/harmonydata/harmony_examples) so that people will know how to use it.

Optionally: feel free to paste your Discord username in this format: `discordapp.com/users/yourID` in your pull request description, then we can know to tag you in the Harmony Discord server when we announce the PR.

`Thomas Wood`
