### PR TITLE
    Crosswalk now takes instruments as input and allows user to enforce 1:1 matching or allow within instrument matches

### DIFF
--- a/tests/test_crosswalk.py
+++ b/tests/test_crosswalk.py
@@ -27,63 +27,65 @@ SOFTWARE.
 
 import sys
 import unittest
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 
 sys.path.append("../src")
 
 from harmony.matching.generate_crosswalk_table import generate_crosswalk_table
+from harmony import create_instrument_from_list
 from harmony import match_instruments
-from harmony.schemas.requests.text import Instrument, Question
+
 
 class TestGenerateCrosswalkTable(unittest.TestCase):
     def setUp(self):
         # Sample data
-        self.all_questions_dummy = [
-            Question(question_no="1", question_text="potato"),
-            Question(question_no="2", question_text="tomato"),
-            Question(question_no="3", question_text="radish"),
-        ]
-
-        self.instruments_dummy = Instrument(questions=self.all_questions_dummy)
+        self.instruments_dummy = [create_instrument_from_list(["potato", "tomato", "radish"], instrument_name="veg")]
 
         self.similarity = np.array([
             [1.0, 0.7, 0.9],
             [0.7, 1.0, 0.8],
             [0.9, 0.8, 1.0]
         ])
-        self.all_questions_real = [Question(question_no="1", question_text="Feeling nervous, anxious, or on edge"),
-                        Question(question_no="2", question_text="Not being able to stop or control worrying")]
-        self.instruments = Instrument(questions=self.all_questions_real)
+
+        self.instruments = [create_instrument_from_list(
+            ["Feeling nervous, anxious, or on edge", "Not being able to stop or control worrying"],
+            instrument_name="GAD-7")]
 
         self.threshold = 0.6
 
-
     def test_generate_crosswalk_table_dummy_data(self):
-        result = generate_crosswalk_table(self.instruments_dummy.questions, self.similarity, self.threshold)
+        result = generate_crosswalk_table(self.instruments_dummy, self.similarity, self.threshold,
+                                          is_allow_within_instrument_matches=True)
 
         expected_matches = [
-            {"pair_name": "0_1", "question1_no": "1", "question1_text": "potato",
-             "question2_no": "2", "question2_text": "tomato", "match_score": 0.7},
-            {"pair_name": "0_2", "question1_no": "1", "question1_text": "potato",
-             "question2_no": "3", "question2_text": "radish", "match_score": 0.9},
-            {"pair_name": "1_2", "question1_no": "2", "question1_text": "tomato",
-             "question2_no": "3", "question2_text": "radish", "match_score": 0.8},
-        ]
-
-        for _, row in pd.DataFrame(expected_matches).iterrows():
-            self.assertTrue(any(row.equals(result_row) for _, result_row in result.iterrows()))
+            {'match_score': 0.9, 'pair_name': 'veg_1_veg_3', 'question1_id': 'veg_1', 'question1_text': 'potato',
+             'question2_id': 'veg_3', 'question2_text': 'radish'},
+            {'match_score': 0.8, 'pair_name': 'veg_2_veg_3', 'question1_id': 'veg_2', 'question1_text': 'tomato',
+             'question2_id': 'veg_3', 'question2_text': 'radish'},
+            {'match_score': 0.7, 'pair_name': 'veg_1_veg_2', 'question1_id': 'veg_1', 'question1_text': 'potato',
+             'question2_id': 'veg_2', 'question2_text': 'tomato'}]
 
         self.assertEqual(len(result), len(expected_matches))
 
+        for row_idx, expected_row in enumerate(expected_matches):
+            self.assertEqual(expected_row["match_score"], result["match_score"].iloc[row_idx])
+            self.assertEqual(expected_row["pair_name"], result["pair_name"].iloc[row_idx])
+            self.assertEqual(expected_row["question1_id"], result["question1_id"].iloc[row_idx])
+            self.assertEqual(expected_row["question2_id"], result["question2_id"].iloc[row_idx])
+            self.assertEqual(expected_row["question1_text"], result["question1_text"].iloc[row_idx])
+            self.assertEqual(expected_row["question2_text"], result["question2_text"].iloc[row_idx])
+
     def test_generate_crosswalk_table_empty(self):
         empty_similarity = np.eye(3)  # Identity matrix, no matches above threshold
-        result = generate_crosswalk_table(self.all_questions_dummy, empty_similarity, self.threshold)
+        result = generate_crosswalk_table(self.instruments_dummy, empty_similarity, self.threshold)
         self.assertTrue(result.empty)
 
     def test_generate_crosswalk_table_real(self):
-        all_questions, similarity_with_polarity, _, _ = match_instruments([self.instruments])
-        result = generate_crosswalk_table(all_questions, similarity_with_polarity, self.threshold)
+        all_questions, similarity_with_polarity, _, _ = match_instruments(self.instruments)
+        result = generate_crosswalk_table(self.instruments, similarity_with_polarity, self.threshold,
+                                          is_allow_within_instrument_matches=True)
         expected_matches = []
 
         for _, row in pd.DataFrame(expected_matches).iterrows():
@@ -92,9 +94,34 @@ class TestGenerateCrosswalkTable(unittest.TestCase):
         self.assertEqual(len(result), len(expected_matches))
 
         lower_threshold = 0.5
-        result = generate_crosswalk_table(all_questions, similarity_with_polarity, lower_threshold)
+        result = generate_crosswalk_table(self.instruments, similarity_with_polarity, lower_threshold,
+                                          is_allow_within_instrument_matches=True)
 
         self.assertEqual(len(result), 1)
+
+    def test_crosswalk_two_instruments_allow_many_to_one_matches(self):
+
+        instrument_1 = create_instrument_from_list(["I felt fearful."])
+        instrument_2 = create_instrument_from_list(
+            ["Feeling afraid, as if something awful might happen", "Feeling nervous, anxious, or on edge"])
+        instruments = [instrument_1, instrument_2]
+
+        all_questions, similarity_with_polarity, _, _ = match_instruments(instruments)
+        result = generate_crosswalk_table(instruments, similarity_with_polarity, 0, is_enforce_one_to_one=False)
+
+        self.assertEqual(2, len(result))
+
+    def test_crosswalk_two_instruments_enforce_one_to_one_matches(self):
+
+        instrument_1 = create_instrument_from_list(["I felt fearful."])
+        instrument_2 = create_instrument_from_list(
+            ["Feeling afraid, as if something awful might happen", "Feeling nervous, anxious, or on edge"])
+        instruments = [instrument_1, instrument_2]
+
+        all_questions, similarity_with_polarity, _, _ = match_instruments(instruments)
+        result = generate_crosswalk_table(instruments, similarity_with_polarity, 0, is_enforce_one_to_one=True)
+
+        self.assertEqual(1, len(result))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

In the crosswalk table users have requested that we should allow multiple matches to one item
 -> allow this to be an option that the user turns on and off

We have also had a request for a unique ID for each question e.g. instrument name + question number

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Requires a documentation revision

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] `test_crosswalk.py`

Since the Harmony Python package is used by the Harmony API (which is itself used by the R library and the web app), we need to avoid making any changes that break the Harmony API. Please also run the Harmony API unit tests and check that the API still runs with your changes to the Python package: https://github.com/harmonydata/harmonyapi

#### Test Configuration

* Library version: 1.0.1
* OS: Ubuntu
* Toolchain: Pycharm

## Checklist

- [X] My code follows the style guidelines of this project. I have applied a Linter (recommended: Pycharm's code formatter) to make my whitespace consistent with the rest of the project.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] The Harmony API is not broken by my change to the Harmony Python library
- [X] I add third party dependencies only when necessary. If I changed the requirements, it changes in `requirements.txt`, `pyproject.toml` and also in the `requirements.txt` in the [API repo](https://github.com/harmonydata/harmonyapi)

Optionally: feel free to paste your Discord username in this format: `discordapp.com/users/yourID` in your pull request description, then we can know to tag you in the Harmony Discord server when we announce the PR.
