### PR TITLE
Add H-score as output value

### DIFF
--- a/src/harmony/matching/default_matcher.py
+++ b/src/harmony/matching/default_matcher.py
@@ -33,6 +33,8 @@ from harmony.schemas.requests.text import Instrument
 from numpy import ndarray
 from sentence_transformers import SentenceTransformer
 
+from harmony.schemas.responses.text import HarmonyMatchResponse
+
 if (
         os.environ.get("HARMONY_SENTENCE_TRANSFORMER_PATH", None) is not None
         and os.environ.get("HARMONY_SENTENCE_TRANSFORMER_PATH", None) != ""
@@ -76,7 +78,7 @@ def match_instruments(
         mhc_embeddings: np.ndarray = np.zeros((0, 0)),
         texts_cached_vectors: dict[str, List[float]] = {}, batch_size: int = 1000, max_batches: int = 2000,
         is_negate: bool = True
-) -> tuple:
+) -> HarmonyMatchResponse:
     return match_instruments_with_function(
         instruments=instruments,
         query=query,

--- a/src/harmony/matching/instrument_to_instrument_similarity.py
+++ b/src/harmony/matching/instrument_to_instrument_similarity.py
@@ -1,0 +1,61 @@
+import operator
+
+import numpy as np
+
+from harmony.schemas.responses.text import InstrumentToInstrumentSimilarity
+
+
+def get_precision_recall_f1(item_to_item_similarity_matrix: np.ndarray) -> tuple:
+    abs_similarities_between_instruments = np.abs(item_to_item_similarity_matrix)
+
+    coord_to_sim = {}
+    for y in range(abs_similarities_between_instruments.shape[0]):
+        for x in range(abs_similarities_between_instruments.shape[1]):
+            coord_to_sim[(y, x)] = abs_similarities_between_instruments[y, x]
+
+    best_matches = set()
+    is_used_x = set()
+    is_used_y = set()
+    for (y, x), sim in sorted(coord_to_sim.items(), key=operator.itemgetter(1), reverse=True):
+        if x not in is_used_x and y not in is_used_y and abs_similarities_between_instruments[(y, x)] >= 0:
+            best_matches.add((x, y))
+
+            is_used_x.add(x)
+            is_used_y.add(y)
+
+    precision = len(is_used_x) / abs_similarities_between_instruments.shape[1]
+    recall = len(is_used_y) / abs_similarities_between_instruments.shape[0]
+
+    f1 = np.mean((precision, recall))
+
+    return precision, recall, f1
+
+
+def get_instrument_similarity(instruments, similarity_with_polarity):
+    instrument_start_pos = []
+    instrument_end_pos = []
+    cur_start = 0
+    for instr_idx in range(len(instruments)):
+        instrument_start_pos.append(cur_start)
+        instrument_end_pos.append(cur_start + len(instruments[instr_idx].questions))
+        cur_start += len(instruments[instr_idx].questions)
+
+    instrument_to_instrument_similarities = []
+
+    for i in range(len(instruments)):
+        instrument_1 = instruments[i]
+        for j in range(i + 1, len(instruments)):
+            instrument_2 = instruments[j]
+            item_to_item_similarity_matrix = similarity_with_polarity[instrument_start_pos[i]:instrument_end_pos[i],
+                                             instrument_start_pos[j]:instrument_end_pos[j]]
+
+            precision, recall, f1 = get_precision_recall_f1(item_to_item_similarity_matrix)
+
+            instrument_to_instrument_similarities.append(
+                InstrumentToInstrumentSimilarity(instrument_1_idx=i, instrument_2_idx=j,
+                                                 instrument_1_name=instrument_1.instrument_name,
+                                                 instrument_2_name=instrument_2.instrument_name, precision=precision,
+                                                 recall=recall, f1=f1)
+            )
+
+    return instrument_to_instrument_similarities

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -27,11 +27,13 @@ SOFTWARE.
 
 import sys
 import unittest
+
 import numpy
 
 sys.path.append("../src")
 
 from harmony.matching.default_matcher import convert_texts_to_vector
+
 
 class createModel:
     def encode(self, sentences, convert_to_numpy=True):
@@ -39,22 +41,19 @@ class createModel:
         return numpy.array([[1] * 768] * len(sentences))
 
 
-
 model = createModel()
+
 
 class TestBatching(unittest.TestCase):
     def test_convert_texts_to_vector_with_batching(self):
         # Create a list of 10 dummy texts
         texts = ["text" + str(i) for i in range(10)]
 
-
         batch_size = 5
         max_batches = 2
         embeddings = convert_texts_to_vector(texts, batch_size=batch_size, max_batches=max_batches)
 
-
         self.assertEqual(embeddings.shape[0], 10)
-
 
         self.assertEqual(embeddings.shape[1], 384)
 

--- a/tests/test_batching_in_matcher.py
+++ b/tests/test_batching_in_matcher.py
@@ -1,11 +1,9 @@
-import sys
 import os
+import sys
 import unittest
-import numpy
 
 sys.path.append("../src")
 from unittest import TestCase, mock
-from harmony.matching.matcher import get_batch_size
 from harmony.matching.matcher import process_items_in_batches
 
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -31,24 +31,26 @@ import unittest
 sys.path.append("../src")
 
 from harmony.matching.cluster import cluster_questions
-from harmony import create_instrument_from_list, import_instrument_into_harmony_web
 from harmony.schemas.requests.text import Instrument, Question
 
 
 class TestCluster(unittest.TestCase):
     def setUp(self):
-        self. all_questions_real = [Question(question_no="1", question_text="Feeling nervous, anxious, or on edge"),
-                              Question(question_no="2", question_text="Not being able to stop or control worrying"),
-                              Question(question_no="3", question_text="Little interest or pleasure in doing things"),
-                              Question(question_no="4", question_text="Feeling down, depressed, or hopeless"),
-                              Question(question_no="5",
-                                       question_text="Trouble falling/staying asleep, sleeping too much"), ]
+        self.all_questions_real = [Question(question_no="1", question_text="Feeling nervous, anxious, or on edge"),
+                                   Question(question_no="2",
+                                            question_text="Not being able to stop or control worrying"),
+                                   Question(question_no="3",
+                                            question_text="Little interest or pleasure in doing things"),
+                                   Question(question_no="4", question_text="Feeling down, depressed, or hopeless"),
+                                   Question(question_no="5",
+                                            question_text="Trouble falling/staying asleep, sleeping too much"), ]
         self.instruments = Instrument(questions=self.all_questions_real)
 
     def test_cluster(self):
         clusters_out, score_out = cluster_questions(self.instruments, 2, False)
-        assert(len(clusters_out) == 5)
+        assert (len(clusters_out) == 5)
         assert score_out
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_convert_text.py
+++ b/tests/test_convert_text.py
@@ -27,8 +27,6 @@ SOFTWARE.
 
 import sys
 import unittest
-from harmony.parsing.text_parser import convert_text_to_instruments
-from harmony.schemas.requests.text import RawFile, FileType
 
 sys.path.append("../src")
 

--- a/tests/test_crosswalk.py
+++ b/tests/test_crosswalk.py
@@ -83,8 +83,8 @@ class TestGenerateCrosswalkTable(unittest.TestCase):
         self.assertTrue(result.empty)
 
     def test_generate_crosswalk_table_real(self):
-        all_questions, similarity_with_polarity, _, _ = match_instruments(self.instruments)
-        result = generate_crosswalk_table(self.instruments, similarity_with_polarity, self.threshold,
+        match_response = match_instruments(self.instruments)
+        result = generate_crosswalk_table(self.instruments, match_response.similarity_with_polarity, self.threshold,
                                           is_allow_within_instrument_matches=True)
         expected_matches = []
 
@@ -94,7 +94,7 @@ class TestGenerateCrosswalkTable(unittest.TestCase):
         self.assertEqual(len(result), len(expected_matches))
 
         lower_threshold = 0.5
-        result = generate_crosswalk_table(self.instruments, similarity_with_polarity, lower_threshold,
+        result = generate_crosswalk_table(self.instruments, match_response.similarity_with_polarity, lower_threshold,
                                           is_allow_within_instrument_matches=True)
 
         self.assertEqual(len(result), 1)
@@ -106,8 +106,9 @@ class TestGenerateCrosswalkTable(unittest.TestCase):
             ["Feeling afraid, as if something awful might happen", "Feeling nervous, anxious, or on edge"])
         instruments = [instrument_1, instrument_2]
 
-        all_questions, similarity_with_polarity, _, _ = match_instruments(instruments)
-        result = generate_crosswalk_table(instruments, similarity_with_polarity, 0, is_enforce_one_to_one=False)
+        match_response = match_instruments(instruments)
+        result = generate_crosswalk_table(instruments, match_response.similarity_with_polarity, 0,
+                                          is_enforce_one_to_one=False)
 
         self.assertEqual(2, len(result))
 
@@ -118,8 +119,9 @@ class TestGenerateCrosswalkTable(unittest.TestCase):
             ["Feeling afraid, as if something awful might happen", "Feeling nervous, anxious, or on edge"])
         instruments = [instrument_1, instrument_2]
 
-        all_questions, similarity_with_polarity, _, _ = match_instruments(instruments)
-        result = generate_crosswalk_table(instruments, similarity_with_polarity, 0, is_enforce_one_to_one=True)
+        match_response = match_instruments(instruments)
+        result = generate_crosswalk_table(instruments, match_response.similarity_with_polarity, 0,
+                                          is_enforce_one_to_one=True)
 
         self.assertEqual(1, len(result))
 

--- a/tests/test_instrument_to_instrument_similarity.py
+++ b/tests/test_instrument_to_instrument_similarity.py
@@ -1,0 +1,72 @@
+'''
+MIT License
+
+Copyright (c) 2023 Ulster University (https://www.ulster.ac.uk).
+Project: Harmony (https://harmonydata.ac.uk)
+Maintainer: Thomas Wood (https://fastdatascience.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+'''
+
+import sys
+import unittest
+
+sys.path.append("../src")
+
+from harmony import match_instruments
+from harmony import create_instrument_from_list
+
+
+class TestInstrumentToInstrumentSimilarity(unittest.TestCase):
+
+    def test_same_instrument_twice(self):
+        gad_2 = create_instrument_from_list(
+            ["Feeling nervous, anxious, or on edge", "Not being able to stop or control worrying"])
+        instruments = [gad_2, gad_2]
+
+        match_response = match_instruments(
+            instruments)
+
+        self.assertEqual(4, len(match_response.questions))
+        self.assertEqual(4, len(match_response.similarity_with_polarity))
+        self.assertEqual(1, len(match_response.instrument_to_instrument_similarities))
+        self.assertEqual(1, match_response.instrument_to_instrument_similarities[0].precision)
+        self.assertEqual(1, match_response.instrument_to_instrument_similarities[0].recall)
+        self.assertEqual(1, match_response.instrument_to_instrument_similarities[0].f1)
+
+    def test_two_instruments_one_a_subset_of_another(self):
+        gad_2 = create_instrument_from_list(
+            ["Feeling nervous, anxious, or on edge", "Not being able to stop or control worrying"])
+        gad_1 = create_instrument_from_list(
+            ["Feeling nervous, anxious, or on edge"])
+        instruments = [gad_2, gad_1]
+
+        match_response = match_instruments(
+            instruments)
+        self.assertEqual(3, len(match_response.questions))
+        self.assertEqual(3, len(match_response.similarity_with_polarity))
+        self.assertEqual(1, len(match_response.instrument_to_instrument_similarities))
+        self.assertEqual(1, match_response.instrument_to_instrument_similarities[0].precision)
+        self.assertEqual(0.5, match_response.instrument_to_instrument_similarities[0].recall)
+        self.assertEqual(0.75, match_response.instrument_to_instrument_similarities[0].f1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -121,36 +121,36 @@ instrument_2 = Instrument.model_validate({
 class TestMatch(unittest.TestCase):
 
     def test_single_instrument_simple(self):
-        all_questions, similarity_with_polarity, query_similarity, new_vectors_dict = match_instruments([instrument_en])
-        self.assertEqual(2, len(all_questions))
-        self.assertEqual(2, len(similarity_with_polarity))
-        self.assertLess(0.99, similarity_with_polarity[0][0])
-        self.assertGreater(0.95, similarity_with_polarity[0][1])
-        self.assertLess(0.99, similarity_with_polarity[1][1])
-        self.assertGreater(0.95, similarity_with_polarity[1][0])
+        match_response = match_instruments([instrument_en])
+        self.assertEqual(2, len(match_response.questions))
+        self.assertEqual(2, len(match_response.similarity_with_polarity))
+        self.assertLess(0.99, match_response.similarity_with_polarity[0][0])
+        self.assertGreater(0.95, match_response.similarity_with_polarity[0][1])
+        self.assertLess(0.99, match_response.similarity_with_polarity[1][1])
+        self.assertGreater(0.95, match_response.similarity_with_polarity[1][0])
 
     def test_two_instruments_simple(self):
-        all_questions, similarity_with_polarity, query_similarity, new_vectors_dict = match_instruments(
+        match_response = match_instruments(
             [instrument_en, instrument_pt])
-        self.assertEqual(4, len(all_questions))
-        self.assertEqual(4, len(similarity_with_polarity))
-        self.assertLess(0.99, similarity_with_polarity[0][0])
+        self.assertEqual(4, len(match_response.questions))
+        self.assertEqual(4, len(match_response.similarity_with_polarity))
+        self.assertLess(0.99, match_response.similarity_with_polarity[0][0])
 
     def test_single_instrument_full_metadata(self):
-        all_questions, similarity_with_polarity, query_similarity, new_vectors_dict = match_instruments([instrument_1])
-        self.assertEqual(2, len(all_questions))
-        self.assertEqual(2, len(similarity_with_polarity))
-        self.assertLess(0.99, similarity_with_polarity[0][0])
-        self.assertGreater(0.95, similarity_with_polarity[0][1])
-        self.assertLess(0.99, similarity_with_polarity[1][1])
-        self.assertGreater(0.95, similarity_with_polarity[1][0])
+        match_response = match_instruments([instrument_1])
+        self.assertEqual(2, len(match_response.questions))
+        self.assertEqual(2, len(match_response.similarity_with_polarity))
+        self.assertLess(0.99, match_response.similarity_with_polarity[0][0])
+        self.assertGreater(0.95, match_response.similarity_with_polarity[0][1])
+        self.assertLess(0.99, match_response.similarity_with_polarity[1][1])
+        self.assertGreater(0.95, match_response.similarity_with_polarity[1][0])
 
     def test_two_instruments_full_metadata(self):
-        all_questions, similarity_with_polarity, query_similarity, new_vectors_dict = match_instruments(
+        match_response = match_instruments(
             [instrument_1, instrument_2])
-        self.assertEqual(4, len(all_questions))
-        self.assertEqual(4, len(similarity_with_polarity))
-        self.assertLess(0.99, similarity_with_polarity[0][0])
+        self.assertEqual(4, len(match_response.questions))
+        self.assertEqual(4, len(match_response.similarity_with_polarity))
+        self.assertLess(0.99, match_response.similarity_with_polarity[0][0])
 
 
 if __name__ == '__main__':

--- a/tests/test_match_mhc.py
+++ b/tests/test_match_mhc.py
@@ -59,13 +59,13 @@ mhc_questions = [Question(question_text=t) for t in mhc_questions_as_text]
 class TestMatchMhc(unittest.TestCase):
 
     def test_single_instrument_simple(self):
-        all_questions, similarity_with_polarity, query_similarity, new_vectors_dict = match_instruments([instrument_en],
-                                                                                                        mhc_questions=mhc_questions,
-                                                                                                        mhc_embeddings=mhc_embeddings,
-                                                                                                        mhc_all_metadatas=mhc_metadata)
-        self.assertEqual(2, len(all_questions))
+        match_response = match_instruments([instrument_en],
+                                           mhc_questions=mhc_questions,
+                                           mhc_embeddings=mhc_embeddings,
+                                           mhc_all_metadatas=mhc_metadata)
+        self.assertEqual(2, len(match_response.questions))
 
-        topics = all_questions[0].topics_strengths
+        topics = match_response.questions[0].topics_strengths
         top_topic = list(topics)[0]
         self.assertEqual("alcohol use", top_topic)
         self.assertLess(0.1, topics[top_topic])

--- a/tests/test_match_negative_polarity.py
+++ b/tests/test_match_negative_polarity.py
@@ -41,23 +41,23 @@ instrument_en = Instrument(questions=questions_en)
 class TestMatch(unittest.TestCase):
 
     def test_single_instrument_with_negation_on_as_default(self):
-        all_questions, similarity_with_polarity, query_similarity, new_vectors_dict = match_instruments([instrument_en])
-        self.assertEqual(2, len(all_questions))
-        self.assertEqual(2, len(similarity_with_polarity))
-        self.assertLess(0.99, similarity_with_polarity[0][0])
-        self.assertGreater(0, similarity_with_polarity[0][1])
-        self.assertLess(0.99, similarity_with_polarity[1][1])
-        self.assertGreater(0, similarity_with_polarity[1][0])
+        match_response = match_instruments([instrument_en])
+        self.assertEqual(2, len(match_response.questions))
+        self.assertEqual(2, len(match_response.similarity_with_polarity))
+        self.assertLess(0.99, match_response.similarity_with_polarity[0][0])
+        self.assertGreater(0, match_response.similarity_with_polarity[0][1])
+        self.assertLess(0.99, match_response.similarity_with_polarity[1][1])
+        self.assertGreater(0, match_response.similarity_with_polarity[1][0])
 
     def test_single_instrument_without_negation(self):
-        all_questions, similarity_with_polarity, query_similarity, new_vectors_dict = match_instruments([instrument_en],
-                                                                                                        is_negate=False)
-        self.assertEqual(2, len(all_questions))
-        self.assertEqual(2, len(similarity_with_polarity))
-        self.assertLess(0.99, similarity_with_polarity[0][0])
-        self.assertLess(0, similarity_with_polarity[0][1])
-        self.assertLess(0.99, similarity_with_polarity[1][1])
-        self.assertLess(0, similarity_with_polarity[1][0])
+        match_response = match_instruments([instrument_en],
+                                           is_negate=False)
+        self.assertEqual(2, len(match_response.questions))
+        self.assertEqual(2, len(match_response.similarity_with_polarity))
+        self.assertLess(0.99, match_response.similarity_with_polarity[0][0])
+        self.assertLess(0, match_response.similarity_with_polarity[0][1])
+        self.assertLess(0.99, match_response.similarity_with_polarity[1][1])
+        self.assertLess(0, match_response.similarity_with_polarity[1][0])
 
 
 if __name__ == '__main__':

--- a/tests/test_pdf_tables.py
+++ b/tests/test_pdf_tables.py
@@ -30,31 +30,28 @@ import unittest
 
 sys.path.append("../src")
 
-from harmony import convert_pdf_to_instruments
 from harmony.schemas.requests.text import RawFile
-from harmony import download_models
-
 
 pdf_empty_table = RawFile.model_validate({
     "file_id": "d39f31718513413fbfc620c6b6135d0c",
     "file_name": "GAD-7.pdf",
     "file_type": "pdf",
     "tables": [],
-    "text_content":"aaa",
-    "content":""
+    "text_content": "aaa",
+    "content": ""
 })
 
 pdf_non_empty_table = RawFile.model_validate({
     "file_id": "d39f31718513413fbfc620c6b6135d0c",
     "file_name": "GAD-7.pdf",
     "file_type": "pdf",
-   'tables': [["hello"]],
-    "text_content":"aaa",
-        "content":""
+    'tables': [["hello"]],
+    "text_content": "aaa",
+    "content": ""
 })
 
-class TestConvertPdfTables(unittest.TestCase):
 
+class TestConvertPdfTables(unittest.TestCase):
     pass
 
     # Not using tables at the moment


### PR DESCRIPTION
## Description

https://github.com/harmonydata/harmony/issues/41

Ideally Harmony could say that e.g. the GAD-7 is e.g. 60% similar to the PHQ-9

See Colab notebook on WMD (Word Movers Distance):
https://github.com/harmonydata/experiments/blob/main/harmony_wmd_experiment.ipynb


I tried coming up with a way of scoring the instrument vs instrument similarity since this has been discussed a number of times.
I wanted to find a way of going from the matrix of cosine scores, to a similarity between two instruments.
I put my experiments here:
https://github.com/harmonydata/h_score/blob/main/experiment_with_different_h_score_metrics.ipynb

I could not think of a coherent way of describing this in an email, but we can discuss at some point.

I think I have an acceptable way of calculating the instrument vs instrument cosine similarity, which is basically getting the crosswalk table, and averaging the values in it, and dividing by the number of items that should have been matched. 
My conditions are that:
1) if you remove a question e.g. match the first six questions of GAD-7 vs the whole GAD-7, you should get a score about 6/7
2) if you reverse the items in a questionnaire, it should still match 100%
3) I made a gold standard where I defined what I think the score should be for a few combinations like this, e.g. GAD-7 vs CES-D should be about 50%. Of course this is subjective and we can adjust it.

If we do this, we can get two measures of similarity between instruments - since one instrument may have 100 items and one instrument has 10, the similarity is not symmetric, so my formula that I'm proposing gives us a separate similarity metric in both directions (I called them [precision and recall](https://en.wikipedia.org/wiki/Precision_and_recall), since that's the terminology used in NLP when you have a query and you are trying to retrieve a document), and we can average them to get an overall similarity metric (called the F1 score, also a term that is used in NLP for the mean of precision and recall).

#### Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Requires a documentation revision

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] `test_instrument_to_instrument_similarity.py`

Since the Harmony Python package is used by the Harmony API (which is itself used by the R library and the web app), we need to avoid making any changes that break the Harmony API. Please also run the Harmony API unit tests and check that the API still runs with your changes to the Python package: https://github.com/harmonydata/harmonyapi

#### Test Configuration

* Library version: 1.0.1
* OS: Ubuntu
* Toolchain: Pycharm

## Checklist

- [X] My code follows the style guidelines of this project. I have applied a Linter (recommended: Pycharm's code formatter) to make my whitespace consistent with the rest of the project.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] The Harmony API is not broken by my change to the Harmony Python library - see near simultaneous commit in API library
- [X] I add third party dependencies only when necessary. If I changed the requirements, it changes in `requirements.txt`, `pyproject.toml` and also in the `requirements.txt` in the [API repo](https://github.com/harmonydata/harmonyapi)
- [ ] If I introduced a new feature, I documented it (e.g. making a script example in the [script examples repository](https://github.com/harmonydata/harmony_examples) so that people will know how to use it.

Optionally: feel free to paste your Discord username in this format: `discordapp.com/users/yourID` in your pull request description, then we can know to tag you in the Harmony Discord server when we announce the PR.
