### PR TITLE
(#76) Prevent crash in language detection due to empty or non-standard input

### DIFF
--- a/src/harmony/parsing/excel_parser.py
+++ b/src/harmony/parsing/excel_parser.py
@@ -120,7 +120,10 @@ def convert_excel_to_instruments(file: RawFile) -> List[Instrument]:
 
         language = "en"
         try:
-            language = detect(" ".join(df_questions["question"]))
+            valid_questions = df_questions["question"].dropna()
+            valid_questions = [q for q in valid_questions if isinstance(q, str) and q.strip()]
+            if valid_questions:
+                language = detect(" ".join(df_questions["question"]))
         except:
             print("Error identifying language in Excel file")
             traceback.print_exc()


### PR DESCRIPTION
Fix crash in convert_excel_to_instruments() by filtering out empty and non-string values before calling detect()

## Description

This pull request aims to present a possible solution to fix issue #76, which was causing a crash in the convert_excel_to_instruments() function due to the langdetect.detect() function receiving empty or invalid input. The error traceback indicated that the function was raising a LangDetectExceptionCode: No features in text. when it was provided with an empty string.

#### Fixes # 76

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My PR is for one issue, rather than for multiple unrelated fixes.
- [x] My code follows the style guidelines of this project. I have applied a Linter (recommended: Pycharm's code formatter) to make my whitespace consistent with the rest of the project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] The Harmony API is not broken by my change to the Harmony Python library

