### PR TITLE
Fix, use filtered valid_questions for language detection (closes #76)

### DIFF
--- a/src/harmony/parsing/excel_parser.py
+++ b/src/harmony/parsing/excel_parser.py
@@ -123,7 +123,7 @@ def convert_excel_to_instruments(file: RawFile) -> List[Instrument]:
             valid_questions = df_questions["question"].dropna()
             valid_questions = [q for q in valid_questions if isinstance(q, str) and q.strip()]
             if valid_questions:
-                language = detect(" ".join(df_questions["question"]))
+                language = detect(" ".join(valid_questions))
         except:
             print("Error identifying language in Excel file")
             traceback.print_exc()


### PR DESCRIPTION
## Description
Fixed a bug where the 'detect()' func was receiving unfiltered data instead of the filtered 'valid_questions' list, causing 'LangDetectException: No features in text' errors when processing Excel files with empty or invalid question text.

#### Fixes #76

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue
- [x] Only one line changed in this one file

## Testing
- [x] Verified that the fix passes the filtered 'valid_questions' to 'detect()' instead of the raw 'df_questions["question"]'
- [x] No new dependencies added

#### Test Configuration
* Library version: Latest main branch
* OS: Windows
* Toolchain: Python 3.x

## Checklist
- [x] My PR is for one issue, rather than for multiple unrelated fixes.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] The Harmony API is not broken by my change to the Harmony Python library


I hope this PR checklist suffices! Simple fix so did not include all checklist criteria :)