### PR TITLE
Add Dockerfile, docker-compose and CI workflow for easier local devel…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.git
+.github
+*.egg-info
+dist/
+build/
+.env
+.venv
+venv/
+*.ipynb
+.tox/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,30 @@
+name: Docker Build and Test
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t harmony-test .
+
+      - name: Run tests inside Docker container
+        run: |
+          docker run \
+            -e HARMONY_LITE=no_transformers \
+            -e PYTHONPATH=/app/src \
+            harmony-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.10-slim
+
+# Install Java (required by Tika for PDF parsing)
+RUN apt-get update && apt-get install -y \
+    default-jdk \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set Java environment
+ENV JAVA_HOME=/usr/lib/jvm/default-java
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+WORKDIR /app
+
+# Copy and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install dev dependencies
+RUN pip install --no-cache-dir pytest tox
+
+# Copy source code
+COPY . .
+
+# Set Python path so src/ is found
+ENV PYTHONPATH=/app/src
+
+CMD ["python", "-m", "pytest", "tests/", "-v"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  harmony:
+    build: .
+    volumes:
+      - .:/app
+      - harmony_models:/root/harmony
+    environment:
+      - PYTHONPATH=/app/src
+      - HARMONY_LITE=no_transformers
+    command: python -m pytest tests/ -v
+
+volumes:
+  harmony_models:


### PR DESCRIPTION
Fixes #127

## What this PR does
Adds Docker support for local development and testing.

## Changes
- `Dockerfile` — Python 3.10 + Java + Tika + all dependencies
- `docker-compose.yml` — easy local dev with model caching via volumes
- `.github/workflows/docker.yml` — auto builds and tests via Docker on every push/PR
- `.dockerignore` — keeps image clean and small

## Why
Currently contributors need to manually install Python, Java 
and Tika to run tests locally. This setup handles everything 
automatically — works on any machine, any OS.

## How to test locally
docker-compose up

## Notes
First run downloads ~612MB spaCy models — subsequent runs 
are faster due to volume caching.