### PR TITLE
add ruff config and clean unused imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,27 @@ dependencies = [
 [project.optional-dependencies]
 
 # dev - the developer dependency set, for contributors to harmony
-dev = ["check-manifest", "pytest", "matplotlib"]
+dev = ["check-manifest", "pytest", "matplotlib", "ruff"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+extend-exclude = ["update.ipynb", "Harmony_example_walkthrough.ipynb"]
+
+[tool.ruff.lint]
+# Pragmatic baseline for a legacy research codebase:
+# enable pyflakes (real bugs), ignore stylistic noise that would require
+# touching many files for no functional gain.
+select = ["F", "E9"]
+ignore = [
+    "F403",   # `from module import *` — used intentionally in __init__.py
+    "F405",   # `*`-import undefined names — paired with F403
+    "F841",   # unused local — common in legacy code, low value to fix now
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]  # re-exports
+"tests/*" = ["F401"]
 
 [project.urls]
 "Documentation" = "https://harmonydata.ac.uk/frequently-asked-questions/"

--- a/src/harmony/matching/cluster.py
+++ b/src/harmony/matching/cluster.py
@@ -8,9 +8,7 @@ from sklearn.metrics import silhouette_score
 
 from harmony.matching.default_matcher import convert_texts_to_vector
 from harmony.schemas.requests.text import Question
-from harmony.schemas.responses.text import HarmonyCluster
 
-import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
 from harmony.matching.deterministic_clustering import find_clusters_deterministic
 

--- a/src/harmony/matching/kmeans_clustering.py
+++ b/src/harmony/matching/kmeans_clustering.py
@@ -1,17 +1,11 @@
-import sys
 from typing import List
 
-import pandas as pd
 from sklearn.cluster import KMeans
-from sklearn.decomposition import PCA
-from sklearn.metrics import silhouette_score
 
 from harmony.matching.generate_cluster_topics import generate_cluster_topics
 from harmony.schemas.requests.text import Question
 from harmony.schemas.responses.text import HarmonyCluster
 
-import numpy as np
-from sklearn.metrics.pairwise import cosine_similarity
 
 
 def perform_kmeans(embeddings_in, num_clusters=5):

--- a/src/harmony/matching/wmd_matcher.py
+++ b/src/harmony/matching/wmd_matcher.py
@@ -1,4 +1,3 @@
-from wmd import WMD
 import numpy as np
 import math
 import libwmdrelax

--- a/src/harmony/parsing/html_parser.py
+++ b/src/harmony/parsing/html_parser.py
@@ -33,7 +33,7 @@ except ImportError:
     
 # Try to import lxml for better performance, fall back to html.parser
 try:
-    import lxml
+    import lxml  # noqa: F401  # availability probe
     DEFAULT_PARSER = 'lxml'
 except ImportError:
     DEFAULT_PARSER = 'html.parser'

--- a/src/harmony/schemas/requests/text.py
+++ b/src/harmony/schemas/requests/text.py
@@ -26,13 +26,12 @@ SOFTWARE.
 '''
 
 import uuid
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from pydantic import ConfigDict, BaseModel, Field
 from harmony.schemas.catalogue_instrument import CatalogueInstrument
 from harmony.schemas.catalogue_question import CatalogueQuestion
 from harmony.schemas.enums.file_types import FileType
 from harmony.schemas.enums.languages import Language
-from typing import Any, Dict
 
 DEFAULT_FRAMEWORK = "huggingface"
 DEFAULT_MODEL = 'sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2'

--- a/src/harmony/schemas/requests/text.py
+++ b/src/harmony/schemas/requests/text.py
@@ -32,8 +32,7 @@ from harmony.schemas.catalogue_instrument import CatalogueInstrument
 from harmony.schemas.catalogue_question import CatalogueQuestion
 from harmony.schemas.enums.file_types import FileType
 from harmony.schemas.enums.languages import Language
-from pydantic import ConfigDict, BaseModel, Field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 DEFAULT_FRAMEWORK = "huggingface"
 DEFAULT_MODEL = 'sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2'

--- a/src/harmony/services/export_pdf_report.py
+++ b/src/harmony/services/export_pdf_report.py
@@ -1,7 +1,6 @@
 import os
-import io
 from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 import tempfile
 from fpdf import FPDF
 

--- a/src/harmony/util/url_loader.py
+++ b/src/harmony/util/url_loader.py
@@ -90,7 +90,7 @@ class URLDownloader:
             parsed = urllib.parse.urlparse(url)
 
             if parsed.scheme not in ALLOWED_SCHEMES:
-                raise BadRequestError(f"URL must use HTTPS")
+                raise BadRequestError("URL must use HTTPS")
 
             if not parsed.netloc or '.' not in parsed.netloc:
                 raise BadRequestError("Invalid domain")


### PR DESCRIPTION
## Description

Adds a pragmatic ruff configuration to `pyproject.toml` and removes unused imports flagged by it across 7 files. No runtime behaviour changes.

The ruff config is intentionally conservative for a legacy research codebase:
- enables pyflakes (`F`) and syntax-errors (`E9`) — real bugs only
- ignores stylistic noise that would require touching many files for no functional gain (`F403`, `F405`, `F841`)
- per-file ignores for `__init__.py` re-exports and `tests/*`

Adds `ruff` to the `dev` optional-deps so contributors get it via `pip install -e ".[dev]"`.

#### Fixes # (no specific issue — infrastructure)

## Type of change

- [x] New feature (non-breaking change which adds functionality) — tooling only

## Testing

- [x] `pytest tests/ --ignore=tests/test_visualize_questions_gui.py` → passes (6 unrelated pre-existing CSV failures on `main` are addressed by sibling PR for `pd.read_csv(sep=None)` deprecation)
- [x] `ruff check src tests` → all checks passed

#### Test Configuration

* Library version: this branch
* OS: macOS 14
* Toolchain: Python 3.11, ruff 0.x

## Checklist

- [x] My PR is for one issue, rather than for multiple unrelated fixes.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes