### PR TITLE
CI hygiene: drop dead env, bump actions, cache pip, enforce ruff

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,5 @@ jobs:
       - name: Run tests inside Docker container
         run: |
           docker run \
-            -e HARMONY_LITE=no_transformers \
             -e PYTHONPATH=/app/src \
             harmony-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
       - name: Install Tox
         run: pip install tox
       - name: Setup Java

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: pyproject.toml
+      - name: Lint with ruff
+        run: |
+          pip install ruff
+          ruff check src tests
       - name: Install Tox
         run: pip install tox
       - name: Setup Java

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
         python: [3.10.11]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,7 @@ on:
     paths-ignore:
       - README.md
   workflow_dispatch:
-env:
-  HARMONY_LITE: no_transformers
-          
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/harmony/__init__.py
+++ b/src/harmony/__init__.py
@@ -22,6 +22,7 @@ SOFTWARE.
 __version__ = "1.0.7"
 # TODO: make these configurable at package level
 import os
+import warnings
 from .examples import example_instruments
 from .schemas import *
 from .util.instrument_helper import create_instrument_from_list, import_instrument_into_harmony_web
@@ -58,4 +59,9 @@ if os.environ.get("HARMONY_NO_MATCHING") is None or os.environ.get("HARMONY_NO_M
     try:
         from .matching.default_matcher import match_instruments
     except ModuleNotFoundError:
-        print("Warning: transformers not available. To use transformers, run pip install sentence-transformers")
+        warnings.warn(
+            "transformers not available. To use transformers, run "
+            "pip install sentence-transformers",
+            ImportWarning,
+            stacklevel=2,
+        )


### PR DESCRIPTION
Five small CI/import fixes, one commit each:

1. **Drop `HARMONY_LITE=no_transformers`** from `test.yml` and `docker.yml`. Per `CLAUDE.md`, this env var is set but never read in code — the real switches are `HARMONY_NO_PARSING` / `HARMONY_NO_MATCHING`. CI was running the full stack regardless of this var; dropping it removes a misleading signal without changing what CI exercises.
2. **Bump `actions/checkout@v2 → v4` and `actions/setup-python@v2 → v5`** in `test.yml`. `docker.yml` already uses v4. v2 emits deprecation warnings on each run.
3. **Add `cache: 'pip'`** with `cache-dependency-path: pyproject.toml` to the setup-python step. Torch and transformers are heavy wheels — caching saves significant time per run.
4. **Enforce ruff lint in CI.** PR #130 added the config (`[tool.ruff]` in `pyproject.toml`, pyflakes-only) but no step ran it. Adding `ruff check src tests` before tox ensures the config stays useful.
5. **Replace `print()` with `warnings.warn(..., ImportWarning)`** in `src/harmony/__init__.py` for the "transformers not available" path. Library code shouldn't write to stdout; `ImportWarning` is the standard signal.

All changes are mechanical and zero-risk to test behaviour. Verified locally that `import harmony` still works (both full and `HARMONY_NO_MATCHING=1` modes), and `ruff check src tests` passes against the current config.